### PR TITLE
Fix ratelimit doco

### DIFF
--- a/content/docs/plugins/ratelimit.mdx
+++ b/content/docs/plugins/ratelimit.mdx
@@ -52,13 +52,13 @@ import (
   ratelimitplugin "github.com/Authula/authula/plugins/rate-limit"
 )
 
-ratelimitplugin.New(ratelimitplugintypes.RateLimitPluginConfig{
+ratelimitplugin.New(ratelimitplugin.RateLimitPluginConfig{
   Enabled:  true,
   Provider: ratelimitplugin.RateLimitProviderRedis,
   Window:   time.Minute,
   Max:      100,
   Prefix:   "ratelimit:",
-  CustomRules: map[string]ratelimitplugintypes.RateLimitRule{
+  CustomRules: map[string]ratelimitplugin.RateLimitRule{
     "/some/path": {
       Disabled: true,
     },

--- a/content/docs/plugins/ratelimit.mdx
+++ b/content/docs/plugins/ratelimit.mdx
@@ -49,8 +49,7 @@ cleanup_interval = "1m"    # How often to clean expired entries (default: 1 minu
 
 ```go
 import (
-  ratelimitplugin "github.com/Authula/authula/plugins/ratelimit"
-  ratelimitplugintypes "github.com/Authula/authula/plugins/ratelimit/types"
+  ratelimitplugin "github.com/Authula/authula/plugins/rate-limit"
 )
 
 ratelimitplugin.New(ratelimitplugintypes.RateLimitPluginConfig{


### PR DESCRIPTION
I was setting up the ratelimit plugin via the doco and encountered some differences to the library example. This fixes that so it matches what's in the authula repo.